### PR TITLE
Allow the id_token to be transformed by an QDL script

### DIFF
--- a/scitokens-server/etc/templates/client-template.xml
+++ b/scitokens-server/etc/templates/client-template.xml
@@ -11,7 +11,7 @@
 <entry key="public_key">4b289478ab9e80f43a837620fd09e3484b10bb77</entry>
 <entry key="last_modified_ts">2022-01-19T21:39:03.254Z</entry>
 <entry key="rt_lifetime">1209600000</entry>
-<entry key="cfg">{"tokens":{"access":{"audience":"ANY","type":"sci_token","qdl": {"load": "vfs#/scripts/scitokens/policies.qdl","xmd": {"exec_phase":  ["pre_auth","post_token","post_refresh","post_exchange"]}}}}}</entry>
+<entry key="cfg">{"tokens":{"access":{"audience":"ANY","type":"sci_token","qdl": {"load": "vfs#/scripts/scitokens/policies.qdl","xmd": {"exec_phase":  ["pre_auth","post_token","post_refresh","post_exchange"]}}}, "identity": {"type": "identity", "qdl": {"load": "vfs#/scripts/scitokens/id_token_policies.qdl", "xmd": {"exec_phase": ["post_token", "post_refresh", "post_exchange"]}}}  }}</entry>
 <entry key="proxy_limited">false</entry>
 <entry key="home_url">https://localhost:9443/client2</entry>
 <entry key="sign_tokens">true</entry>

--- a/scitokens-server/var/qdl/scitokens/id_token_policies.qdl
+++ b/scitokens-server/var/qdl/scitokens/id_token_policies.qdl
@@ -1,0 +1,15 @@
+/*
+ Simply prefer the eppn for the subject; otherwise, pass the token through.
+ */
+
+if[
+   is_defined(claims.'eppn')
+][
+   claims.'sub' := claims.'eppn';
+]else[
+  if[
+     is_defined(claims.'email')
+  ][
+   claims.'sub' := claims.'email';
+  ];
+];


### PR DESCRIPTION
Introduces a callout for the id_token returned by OA4MP.

The default script does very little - just changes around the `sub` based on the eppn or email - as this is mostly seen as useful in applications that want to override the default behavior.  However, adding a trivial script to the default template is really the only way to allow the downstream containers to override it.